### PR TITLE
Add bower.json for tada

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "tada",
+  "main": "tada.js",
+  "version": "0.0.1",
+  "homepage": "https://github.com/fallroot/tada",
+  "authors": [
+    "CK Moon <fallroot@gmail.com>"
+  ],
+  "description": "Lightweight, no dependency library for lazy image load.",
+  "keywords": [
+    "lazy",
+    "image"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
`tada` has no bower.json for itself. So I just added it. :)
